### PR TITLE
Dont autopersist in TranslatableEntityHandler

### DIFF
--- a/src/Translation/Handlers/TranslatableEntityHandler.php
+++ b/src/Translation/Handlers/TranslatableEntityHandler.php
@@ -71,8 +71,6 @@ class TranslatableEntityHandler implements TranslationHandlerInterface
 
         $clone->setLocale($args->getTargetLocale());
 
-        $this->em->persist($clone);
-
         return $clone;
     }
 

--- a/tests/Fixtures/AppTestBundle/Entity/Translatable/TranslatableManyToManyBidirectionalParent.php
+++ b/tests/Fixtures/AppTestBundle/Entity/Translatable/TranslatableManyToManyBidirectionalParent.php
@@ -29,6 +29,7 @@ class TranslatableManyToManyBidirectionalParent implements TranslatableInterface
      *
      * @ORM\ManyToMany(
      *     targetEntity="AppTestBundle\Entity\Translatable\TranslatableManyToManyBidirectionalChild",
+     *     cascade={"persist"},
      *     mappedBy="simpleParents"
      * )
      */
@@ -39,6 +40,7 @@ class TranslatableManyToManyBidirectionalParent implements TranslatableInterface
      *
      * @ORM\ManyToMany(
      *     targetEntity="AppTestBundle\Entity\Translatable\TranslatableManyToManyBidirectionalChild",
+     *     cascade={"persist"},
      *     mappedBy="emptyParents"
      * )
      * @ORM\JoinTable(name="empty_translatablemanytomanybidirectionalchild_translatablemanytomanybidirectionalparent")

--- a/tests/ScalarTranslationTest.php
+++ b/tests/ScalarTranslationTest.php
@@ -17,6 +17,7 @@ class ScalarTranslationTest extends AbstractBaseTest
     {
         $entity      = $this->createEntity();
         $translation = $this->translator->translate($entity, 'fr');
+        $this->em->persist($translation);
         $this->em->flush();
         $this->assertAttributeContains('Test title', 'title', $translation);
         $this->assertIsTranslation($entity, $translation);
@@ -48,6 +49,7 @@ class ScalarTranslationTest extends AbstractBaseTest
         $entity      = $this->createEntity();
         $translation = $this->translator->translate($entity, 'fr');
 
+        $this->em->persist($translation);
         $this->em->flush();
         $this->assertAttributeEmpty('empty', $translation);
         $this->assertIsTranslation($entity, $translation);

--- a/tests/TranslatableManyToOneEntityTranslationTest.php
+++ b/tests/TranslatableManyToOneEntityTranslationTest.php
@@ -27,6 +27,7 @@ class TranslatableManyToOneEntityTranslationTest extends AbstractBaseTest
         /** @var TranslatableManyToOne $translation */
         $translation = $this->translator->translate($entity, self::TARGET_LOCALE);
 
+        $this->em->persist($translation);
         $this->em->flush();
         $this->assertNotEquals($associatedEntity, $translation->getSimple());
         $this->assertAttributeContains(self::TARGET_LOCALE, 'locale', $translation->getSimple());
@@ -41,6 +42,7 @@ class TranslatableManyToOneEntityTranslationTest extends AbstractBaseTest
         $this->em->persist($associatedEntity);
 
         $translatedAssociatedEntity = $this->translator->translate($associatedEntity, self::TARGET_LOCALE);
+        $this->em->persist($translatedAssociatedEntity);
 
         $entity =
             (new TranslatableManyToOne())
@@ -52,6 +54,7 @@ class TranslatableManyToOneEntityTranslationTest extends AbstractBaseTest
         /** @var TranslatableManyToOne $translation */
         $translation = $this->translator->translate($entity, self::TARGET_LOCALE);
 
+        $this->em->persist($translation);
         $this->em->flush();
         $this->assertNotEquals($associatedEntity, $translation->getSimple());
         $this->assertEquals($translatedAssociatedEntity, $translation->getSimple());

--- a/tests/TranslatableOneToOneUnidirectionalTest.php
+++ b/tests/TranslatableOneToOneUnidirectionalTest.php
@@ -27,6 +27,7 @@ class TranslatableOneToOneUnidirectionalTest extends AbstractBaseTest
         /** @var TranslatableOneToOneUnidirectional $translation */
         $translation = $this->translator->translate($entity, self::TARGET_LOCALE);
 
+        $this->em->persist($translation);
         $this->em->flush();
         $this->assertNotEquals($associatedEntity, $translation->getSimple());
         $this->assertAttributeContains(self::TARGET_LOCALE, 'locale', $translation->getSimple());


### PR DESCRIPTION
I think `TranslatableEntityHandler` should not call `persist` on the newly created entity, this job should be done by the developer.

When using the `TranslatableCRUDController` for Sonata this modification will be transparent because a `persist` and a `flush` are already done.

Furthermore, in tests, the `persist` was done almost every time so the remaining are fixed and it's now consistent.

I'm open to any suggestion, pros or cons!