### PR TITLE
Suppression d'un flush qui cause des erreurs avec seo-bundle

### DIFF
--- a/src/Doctrine/EventSubscriber/TranslatableEventSubscriber.php
+++ b/src/Doctrine/EventSubscriber/TranslatableEventSubscriber.php
@@ -213,8 +213,6 @@ class TranslatableEventSubscriber implements Common\EventSubscriber
             foreach ($translations as $translation) {
                 $translation->setTranslations($translationsArray);
                 $args->getEntityManager()->persist($translation);
-
-                $em->flush($translation);
             }
         }
     }


### PR DESCRIPTION
Je ne sais pas précisément pourquoi, mais ce flush génère un erreur dans l'utilisation de seo-bundle : 

`An exception occurred while executing 'INSERT INTO umanit_seo_url_reference (id, route, url, locale, seo_uuid) VALUES (?, ?, ?, ?, ?)' with params [1823, "completely_goat_show", "https:\/\/soignon.wip\/completement-chevre\/test-1", null, "a98eff7e-6f47-42d8-8156-959c689d658a"]:


SQLSTATE[23505]: Unique violation: 7 ERROR: duplicate key value violates unique constraint "uniq_97a4b71b2da94077"
DETAIL: Key (seo_uuid)=(a98eff7e-6f47-42d8-8156-959c689d658a) already exists.`