### PR TITLE
Minor change on how the configuration is initialized

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,8 +15,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('umanit_translation');
+        $treeBuilder = new TreeBuilder('umanit_translation');
+        $rootNode    = $treeBuilder->getRootNode();
         $rootNode
             ->children()
                 ->scalarNode('default_locale')->defaultNull()->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,8 +15,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('umanit_translation');
-        $rootNode    = $treeBuilder->getRootNode();
+
+        if (Kernel::VERSION_ID >= 40200) {
+            $builder  = new TreeBuilder('umanit_translation');
+            $rootNode = $builder->getRootNode();
+        } else {
+            $builder  = new TreeBuilder();
+            $rootNode = $builder->root('umanit_translation');
+        }
+
         $rootNode
             ->children()
                 ->scalarNode('default_locale')->defaultNull()->end()


### PR DESCRIPTION
Couldn't install the bundle on Symfony 5.2.

It seems something has changed in the config tree builder, and you now have to pass the configuration root name as a mandatory parameter to the constructor.

I'm not sure whether this change could induce a BC break with older symfony.

Original error from `composer install`

```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  ArgumentCountError {#3564
!!    #message: "Too few arguments to function Symfony\Component\Config\Definition\Builder\TreeBuilder::construct(), 0 passed in /xxxxxxxx/xxxxxxxx/vendor/umanit/translation-bundle/src/DependencyInjection/Configuration.php on line 18 and at least 1 expected"
!!    #code: 0
!!    #file: "./vendor/symfony/config/Definition/Builder/TreeBuilder.php"
!!    #line: 26
!!    trace: {
!!      ./vendor/symfony/config/Definition/Builder/TreeBuilder.php:26 { …}
!!      ./vendor/umanit/translation-bundle/src/DependencyInjection/Configuration.php:18 { …}
!!      ./vendor/symfony/config/Definition/Processor.php:50 { …}
!!      ./vendor/symfony/dependency-injection/Extension/Extension.php:111 { …}
!!      ./vendor/umanit/translation-bundle/src/DependencyInjection/UmanitTranslationExtension.php:24 { …}
!!      ./vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php:76 { …}
!!      ./vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php:39 { …}
!!      ./vendor/symfony/dependency-injection/Compiler/Compiler.php:91 { …}
!!      ./vendor/symfony/dependency-injection/ContainerBuilder.php:736 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:541 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:780 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:121 { …}
!!      ./vendor/symfony/framework-bundle/Console/Application.php:168 { …}
!!      ./vendor/symfony/framework-bundle/Console/Application.php:74 { …}
!!      ./vendor/symfony/console/Application.php:166 { …}
!!      ./bin/console:43 {
!!        › $application = new Application($kernel);
!!        › $application->run($input);
!!        › 
!!        arguments: {
!!          $input: Symfony\Component\Console\Input\ArgvInput {#6 …}
!!        }
!!      }
!!    }
!!  }
!!  2021-05-11T11:21:42+02:00 [critical] Uncaught Error: Too few arguments to function Symfony\Component\Config\Definition\Builder\TreeBuilder::construct(), 0 passed in /home/xxxxxxxxxx/xxxxxxxxxx/vendor/umanit/translation-bundle/src/DependencyInjection/Configuration.php on line 18 and at least 1 expected
!!  
Script @auto-scripts was called via post-update-cmd

Installation failed, reverting ./composer.json to its original content.
```